### PR TITLE
Enforce platform WebAuthn authentication

### DIFF
--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -19,8 +19,13 @@ class AttendanceController extends Controller
             ->whereDate('punch_in_time', Carbon::today())
             ->whereNull('punch_out_time')
             ->first();
+
+        $credentialIds = $user->webauthnCredentials()
+            ->pluck('credential_id');
+
         return view('dashboard', [
             'hasPunchedIn' => $latestAttendance ? true : false,
+            'credentialIds' => $credentialIds,
         ]);
     }
 
@@ -184,8 +189,10 @@ class AttendanceController extends Controller
             return false;
         }
 
-        return $request->user()->webauthnCredentials()
-            ->where('credential_id', $credId)
-            ->exists();
+        $registered = $request->user()->webauthnCredentials()
+            ->pluck('credential_id')
+            ->toArray();
+
+        return in_array($credId, $registered, true);
     }
 }

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -71,6 +71,8 @@
 
     @push('scripts')
 <script>
+    const registeredCreds = @json($credentialIds);
+
     function cameraApp() {
         return {
             showModal: false,
@@ -143,7 +145,17 @@
                     return;
                 }
 
-                navigator.credentials.get({publicKey: {challenge: new Uint8Array(), userVerification: 'preferred'}})
+                navigator.credentials.get({
+                    publicKey: {
+                        challenge: new Uint8Array(),
+                        userVerification: 'required',
+                        allowCredentials: registeredCreds.map(id => ({
+                            type: 'public-key',
+                            id: Uint8Array.from(atob(id), c => c.charCodeAt(0)),
+                            transports: ['internal']
+                        }))
+                    }
+                })
                     .then(cred => {
                         const rawId = btoa(String.fromCharCode(...new Uint8Array(cred.rawId)));
                         document.getElementById('credential_id_' + this.actionType).value = rawId;

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -26,6 +26,12 @@
                 </div>
             </div>
 
+            <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+                <div class="max-w-xl">
+                    @include('profile.partials.webauthn-register-form')
+                </div>
+            </div>
+
         </div>
     </div>
 

--- a/resources/views/profile/partials/webauthn-register-form.blade.php
+++ b/resources/views/profile/partials/webauthn-register-form.blade.php
@@ -1,0 +1,13 @@
+<section class="space-y-6" x-data="{register() { if(!window.PublicKeyCredential) { alert('جهازك لا يدعم التحقق البيومتري'); return; } navigator.credentials.create({publicKey:{challenge:new Uint8Array(), authenticatorSelection:{authenticatorAttachment:'platform', userVerification:'required'}}}).then(c=>{document.getElementById('webauthn_cred').value=btoa(String.fromCharCode(...new Uint8Array(c.rawId))); document.getElementById('webauthn_key').value=''; document.getElementById('webauthnForm').submit();}).catch(()=>alert('فشل تسجيل الجهاز')); }}">
+    <header>
+        <h2 class="text-lg font-medium text-gray-900">تسجيل جهاز بيومتري</h2>
+        <p class="mt-1 text-sm text-gray-600">سجّل جهازك البيومتري لاستخدامه في تسجيل الحضور.</p>
+    </header>
+    <button type="button" class="btn-primary" @click="register()">تسجيل الجهاز</button>
+    <form id="webauthnForm" method="POST" action="{{ route('webauthn.register') }}" class="hidden">
+        @csrf
+        <input type="hidden" name="name" value="platform">
+        <input type="hidden" name="credential_id" id="webauthn_cred">
+        <input type="hidden" name="public_key" id="webauthn_key">
+    </form>
+</section>

--- a/tests/Feature/WebAuthnTest.php
+++ b/tests/Feature/WebAuthnTest.php
@@ -56,3 +56,28 @@ it('rejects punching in with invalid credential', function () {
     $response->assertSessionHas('error');
     expect(AttendanceLog::where('user_id', $user->id)->exists())->toBeFalse();
 });
+
+it('rejects punching in without credential', function () {
+    $location = Location::create([
+        'name' => 'Office',
+        'latitude' => 0,
+        'longitude' => 0,
+        'radius_meters' => 100,
+    ]);
+
+    $user = User::factory()->create(['location_id' => $location->id]);
+    WebAuthnCredential::create([
+        'user_id' => $user->id,
+        'name' => 'finger',
+        'credential_id' => 'valid-cred',
+        'public_key' => 'pk',
+    ]);
+
+    $response = $this->actingAs($user)->post('/punch-in', [
+        'latitude' => 0,
+        'longitude' => 0,
+    ]);
+
+    $response->assertSessionHas('error');
+    expect(AttendanceLog::where('user_id', $user->id)->exists())->toBeFalse();
+});


### PR DESCRIPTION
## Summary
- provide registered credential IDs to the dashboard
- restrict navigator.credentials.get() to platform authenticators
- add platform-only registration section in user profile
- validate WebAuthn credential IDs server‑side
- test absence of credential IDs when punching in

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_b_685e5b2932d0833094dc7698055f9957