### PR TITLE
Fix WebAuthnCredential table mapping

### DIFF
--- a/app/Models/WebAuthnCredential.php
+++ b/app/Models/WebAuthnCredential.php
@@ -10,6 +10,13 @@ class WebAuthnCredential extends Model
 {
     use HasFactory;
 
+    /**
+     * The table associated with the model.
+     * This overrides Laravel's default pluralisation which would
+     * otherwise expect `web_authn_credentials`.
+     */
+    protected $table = 'webauthn_credentials';
+
     protected $fillable = [
         'user_id',
         'name',


### PR DESCRIPTION
## Summary
- set the table name for the WebAuthnCredential model

## Testing
- `npm --version`
- `php --version` *(fails: command not found)*
- `./vendor/bin/phpunit --version` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_b_685e3ee20a0c833089df58f100cfa7a0