### PR TITLE
Extract WebAuthn key on register

### DIFF
--- a/resources/views/profile/partials/webauthn-register-form.blade.php
+++ b/resources/views/profile/partials/webauthn-register-form.blade.php
@@ -1,4 +1,39 @@
-<section class="space-y-6" x-data="{register() { if(!window.PublicKeyCredential) { alert('جهازك لا يدعم التحقق البيومتري'); return; } const challenge = Uint8Array.from(atob('{{ $registerChallenge }}'), c => c.charCodeAt(0)); navigator.credentials.create({publicKey:{challenge:challenge, authenticatorSelection:{authenticatorAttachment:'platform', userVerification:'required'}}}).then(c=>{document.getElementById('webauthn_cred').value=btoa(String.fromCharCode(...new Uint8Array(c.rawId))); document.getElementById('webauthn_key').value=''; document.getElementById('webauthnForm').submit();}).catch(()=>alert('فشل تسجيل الجهاز')); }}">
+<section class="space-y-6"
+    x-data="{
+        register() {
+            if (!window.PublicKeyCredential) {
+                alert('جهازك لا يدعم التحقق البيومتري');
+                return;
+            }
+
+            const challenge = Uint8Array.from(atob('{{ $registerChallenge }}'), c => c.charCodeAt(0));
+
+            navigator.credentials.create({
+                publicKey: {
+                    challenge: challenge,
+                    authenticatorSelection: {
+                        authenticatorAttachment: 'platform',
+                        userVerification: 'required'
+                    }
+                }
+            })
+                .then(c => {
+                    document.getElementById('webauthn_cred').value = btoa(
+                        String.fromCharCode(...new Uint8Array(c.rawId))
+                    );
+
+                    const pk = c.response.getPublicKey();
+                    if (pk) {
+                        document.getElementById('webauthn_key').value = btoa(
+                            String.fromCharCode(...new Uint8Array(pk))
+                        );
+                    }
+
+                    document.getElementById('webauthnForm').submit();
+                })
+                .catch(() => alert('فشل تسجيل الجهاز'));
+        }
+    }">
     <header>
         <h2 class="text-lg font-medium text-gray-900">تسجيل جهاز بيومتري</h2>
         <p class="mt-1 text-sm text-gray-600">سجّل جهازك البيومتري لاستخدامه في تسجيل الحضور.</p>

--- a/tests/Feature/WebAuthnTest.php
+++ b/tests/Feature/WebAuthnTest.php
@@ -81,3 +81,17 @@ it('rejects punching in without credential', function () {
     $response->assertSessionHas('error');
     expect(AttendanceLog::where('user_id', $user->id)->exists())->toBeFalse();
 });
+
+it('stores public key when registering credential', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->post('/webauthn/register', [
+        'name' => 'finger',
+        'credential_id' => 'cred-1',
+        'public_key' => base64_encode('pk-data'),
+    ]);
+
+    $response->assertOk();
+    $cred = WebAuthnCredential::first();
+    expect($cred->public_key)->toBe(base64_encode('pk-data'));
+});


### PR DESCRIPTION
## Summary
- capture the public key when registering a WebAuthn credential
- assert that the key is saved during registration

## Testing
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_685e884ed2088330bf85e082f203919f