### PR TITLE
Remove test openssl route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -86,39 +86,6 @@ Route::middleware(['auth', 'role:HR'])->prefix('HR')->name('HR.')->group(functio
     Route::get('reports/export-employees', [ReportController::class, 'exportEmployees'])->name('reports.export.employees');
     Route::get('balances', [BalanceController::class, 'index'])->name('balances.index');
 });
-if (app()->environment('local')) {
-    Route::get('/test-pure-openssl', function () {
-        try {
-            // هذا هو نفس الكود تماماً الذي يسبب الانهيار داخل المكتبة
-            $keyResource = openssl_pkey_new([
-                'curve_name'       => 'prime256v1',
-                'private_key_type' => OPENSSL_KEYTYPE_EC,
-            ]);
-
-            if (!$keyResource) {
-                return "<h1>فشل: دالة openssl_pkey_new() لم تتمكن من إنشاء المفتاح، ولكن بدون خطأ فادح.</h1>";
-            }
-
-        // إذا نجحت الخطوة السابقة، نحاول الحصول على تفاصيل المفتاح
-            $details = openssl_pkey_get_details($keyResource);
-
-            if (!$details) {
-                return "<h1>فشل: تم إنشاء المفتاح، ولكن لا يمكن قراءة تفاصيله.</h1>";
-            }
-
-        // إذا نجح كل شيء، نعرض رسالة النجاح والتفاصيل
-            echo "<h1>نجاح باهر!</h1>";
-            echo "<p>هذا يعني أن بيئة OpenSSL لديك تعمل بشكل سليم عند استدعائها مباشرة.</p>";
-            echo "<p>المشكلة تكمن في مكتبة web-push.</p>";
-            dd($details);
-
-        } catch (\Throwable $e) {
-            // إذا حدث أي خطأ فادح، نعرضه
-            echo "<h1>حدث خطأ فادح عند محاولة استدعاء الدالة مباشرة:</h1>";
-            dd($e);
-        }
-    });
-}
 
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- delete the `/test-pure-openssl` debug route

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685e9058a7948330bdcb46f20c3b76de