### PR TITLE
Update authentication provider to WebAuthn

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -61,8 +61,9 @@ return [
 
     'providers' => [
         'users' => [
-            'driver' => 'eloquent',
+            'driver' => 'eloquent-webauthn',
             'model' => env('AUTH_MODEL', App\Models\User::class),
+            'password_fallback' => true,
         ],
 
         // 'users' => [


### PR DESCRIPTION
## Summary
- switch the default user provider to `eloquent-webauthn`
- enable `password_fallback` in auth configuration
- attempted to clear configuration cache

## Testing
- `php artisan config:clear` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686234518db483309abb78c2ee5bf45b