### PR TITLE
Add webauthn login page

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -43,5 +43,11 @@
                 {{ __('Log in') }}
             </x-primary-button>
         </div>
+
+        <div class="flex items-center justify-center mt-4">
+            <a href="{{ route('login.webauthn') }}" class="underline text-sm text-gray-600 hover:text-gray-900">
+                {{ __('تسجيل الدخول بالبصمة') }}
+            </a>
+        </div>
     </form>
 </x-guest-layout>

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -29,6 +29,8 @@ Route::middleware('guest')->group(function () {
 
     Route::post('login', [AuthenticatedSessionController::class, 'store']);
 
+    Route::view('login-webauthn', 'auth.login-webauthn')->name('login.webauthn');
+
     Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
                 ->name('password.request');
 


### PR DESCRIPTION
## Summary
- add route to reach the WebAuthn login view
- link from regular login page to the fingerprint login page

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6862345478848330b5bd197d44360fe0