### PR TITLE
Fix WebAuthn test imports

### DIFF
--- a/tests/Feature/AttendanceTest.php
+++ b/tests/Feature/AttendanceTest.php
@@ -2,9 +2,14 @@
 
 use App\Models\User;
 use App\Models\Location;
-use App\Models\WebAuthnCredential;
+use Laragear\WebAuthn\Models\WebAuthnCredential;
+use Laragear\WebAuthn\Http\Routes as WebAuthnRoutes;
 use App\Models\AttendanceLog;
 use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    WebAuthnRoutes::register();
+});
 
 it('rejects punch in when outside allowed location', function () {
     Storage::fake('public');

--- a/tests/Feature/WebAuthnTest.php
+++ b/tests/Feature/WebAuthnTest.php
@@ -2,10 +2,15 @@
 
 use App\Models\User;
 use App\Models\Location;
-use App\Models\WebAuthnCredential;
+use Laragear\WebAuthn\Models\WebAuthnCredential;
+use Laragear\WebAuthn\Http\Routes as WebAuthnRoutes;
 use App\Models\AttendanceLog;
 use Mockery;
 use Webauthn;
+
+beforeEach(function () {
+    WebAuthnRoutes::register();
+});
 
 it('allows punching in with valid credential', function () {
     $location = Location::create([


### PR DESCRIPTION
## Summary
- correct WebAuthnCredential model namespace in feature tests
- register WebAuthn routes in the test suite

## Testing
- `./vendor/bin/phpunit` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_b_6862345579908330af47d6dd27d904fc