### PR TITLE
Fix WebAuthn CSRF exception handling

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -33,7 +33,9 @@ Route::get('/', function () {
 });
 
 // WebAuthn Routes
-WebAuthnRoutes::register()->withoutMiddleware(VerifyCsrfToken::class);
+Route::withoutMiddleware(VerifyCsrfToken::class)->group(function () {
+    WebAuthnRoutes::register();
+});
 
 // Employee Routes
 Route::middleware(['auth'])->group(function () {


### PR DESCRIPTION
## Summary
- ensure WebAuthn routes are grouped without CSRF middleware

## Testing
- `php vendor/bin/pest` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6862428b8b6483308c8c203aa116b8b7