### PR TITLE
Remove unused import from AttendanceController

### DIFF
--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -6,7 +6,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 use App\Models\AttendanceLog;
-use Laragear\WebAuthn\Models\WebAuthnCredential;
 use Carbon\Carbon;
 use Webauthn;
 


### PR DESCRIPTION
## Summary
- cleaned up AttendanceController by removing an unused import

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862541910f08330a7ccb11352540b26