### PR TITLE
Add passkey support check

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -155,6 +155,10 @@
             },
 
             async submitWithPasskey(lat, lon) {
+                if (typeof Webpass === 'undefined' || Webpass.isUnsupported()) {
+                    alert('متصفحك لا يدعم البصمة أو تعذر تحميل المكتبة.');
+                    return;
+                }
                 try {
                     const { success } = await this.webpass.assert(
                         "{{ route('webauthn.login.options') }}",


### PR DESCRIPTION
## Summary
- add a check for Webpass support in dashboard

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68625802ab6c8330961f0b4a15e5cbe1